### PR TITLE
puppet: replace hyperkube with individual binaries

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster.go
+++ b/pkg/apis/cluster/v1alpha1/cluster.go
@@ -108,6 +108,7 @@ type ClusterKubernetes struct {
 	Calico            *ClusterKubernetesCalico            `json:"calico,omitempty"`
 
 	GlobalFeatureGates map[string]bool `json:"globalFeatureGates,omitempty"`
+	Hyperkube          *bool           `json:"hyperkube,omitempty"`
 }
 
 type ClusterKubernetesClusterAutoscaler struct {

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -38,12 +38,18 @@ func SetDefaults_Cluster(obj *Cluster) {
 
 	// set default kubernetes version
 	if obj.Kubernetes.Version == "" {
-		obj.Kubernetes.Version = "1.12.9"
+		obj.Kubernetes.Version = "1.16.15"
 	}
 
 	// zone
 	if obj.Kubernetes.Zone == "" {
 		obj.Kubernetes.Zone = "cluster.local"
+	}
+
+	// set hyperkube usage
+
+	if obj.Kubernetes.Hyperkube == nil {
+		obj.Kubernetes.Hyperkube = boolPointer(true)
 	}
 
 	// podCIDR

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -295,6 +295,20 @@ func kubernetesClusterConfigPerRole(conf *clusterv1alpha1.ClusterKubernetes, rol
 		return
 	}
 
+	// hyperkube usage
+	if conf.Hyperkube != nil {
+		hieraData.variables = append(hieraData.variables, fmt.Sprintf(`kubernetes::use_hyperkube: %t`, *conf.Hyperkube))
+	} else {
+		hieraData.variables = append(hieraData.variables, `kubernetes::use_hyperkube: true`)
+	}
+
+	switch roleName {
+	case clusterv1alpha1.KubernetesMasterRoleName:
+		hieraData.variables = append(hieraData.variables, `kubernetes::release_type: "server"`)
+	default:
+		hieraData.variables = append(hieraData.variables, `kubernetes::release_type: "node"`)
+	}
+
 	if roleName == clusterv1alpha1.KubernetesMasterRoleName {
 		hieraData.classes = append(hieraData.classes, `kubernetes_addons::cluster_autoscaler`)
 		if conf.ClusterAutoscaler != nil && conf.ClusterAutoscaler.Enabled {

--- a/puppet/modules/kubernetes/README.md
+++ b/puppet/modules/kubernetes/README.md
@@ -507,7 +507,17 @@ class kubernetes::master
 
 ### `kubernetes::install`
 
+download and install kubernetes binaries
+
+
+### `kubernetes::hyperkube_install`
+
 download and install hyperkube
+
+
+### `kubernetes::symlink`
+
+adds a symlink to hyperkube
 
 
 ### `kubernetes::kubectl`
@@ -981,7 +991,3 @@ Concat fragment for apply
 * Type: `Any`
 * Default: `'yaml'`
 
-
-### `kubernetes::symlink`
-
-adds a symlink to hyperkube

--- a/puppet/modules/kubernetes/manifests/controller_manager.pp
+++ b/puppet/modules/kubernetes/manifests/controller_manager.pp
@@ -34,7 +34,11 @@ class kubernetes::controller_manager(
 
   $_feature_gates = $feature_gates
 
-  kubernetes::symlink{$command_name:}
+  if $::kubernetes::use_hyperkube {
+      kubernetes::symlink{$command_name:}
+  } else {
+      include kubernetes::install
+  }
   -> file{$kubeconfig_path:
     ensure  => file,
     mode    => '0640',

--- a/puppet/modules/kubernetes/manifests/hyperkube_install.pp
+++ b/puppet/modules/kubernetes/manifests/hyperkube_install.pp
@@ -1,0 +1,22 @@
+# download and install hyperkube
+class kubernetes::hyperkube_install {
+  include kubernetes
+
+  $hyperkube_path = "${::kubernetes::_dest_dir}/hyperkube"
+
+  file { $::kubernetes::_dest_dir:
+    ensure => directory,
+    mode   => '0755',
+  }
+  -> exec {"kubernetes-${kubernetes::version}-download":
+    command => "curl -sL -o  ${hyperkube_path} ${::kubernetes::download_url}",
+    creates => $hyperkube_path,
+    path    => ['/usr/bin/', '/bin'],
+  }
+  -> file {"${::kubernetes::_dest_dir}/hyperkube":
+    ensure => file,
+    mode   => '0755',
+    owner  => 'root',
+    group  => 'root',
+  }
+}

--- a/puppet/modules/kubernetes/manifests/init.pp
+++ b/puppet/modules/kubernetes/manifests/init.pp
@@ -3,6 +3,10 @@ class kubernetes (
   $version = $::kubernetes::params::version,
   $aia_version = $::kubernetes::params::aws_authenticator_version,
   $bin_dir = $::kubernetes::params::bin_dir,
+  $os_release = $::kubernetes::params::os_release,
+  $release_arch = $::kubernetes::params::release_arch,
+  $use_hyperkube = true,
+  $release_type = 'node',
   $aia_bin_dir = '/opt/aws_authenticator',
   $download_dir = $::kubernetes::params::download_dir,
   $dest_dir = $::kubernetes::params::dest_dir,
@@ -67,6 +71,13 @@ class kubernetes (
     $_authorization_mode = $authorization_mode
   }
 
+  # detect binaries to expect based on release type
+  if $release_type == 'server' {
+    $binaries = ['kubeadm', 'apiextensions-apiserver', 'kube-apiserver', 'kubelet', 'kube-proxy', 'kubectl', 'kube-controller-manager', 'mounter', 'kube-scheduler']
+  } else {
+      $binaries = ['kubeadm', 'kubelet', 'kube-proxy', 'kubectl']
+  }
+
   if $apiserver_insecure_port == -1 and versioncmp($version, '1.6.0') < 0 {
     $_apiserver_insecure_port = 8080
   } elsif $apiserver_insecure_port == -1 {
@@ -117,6 +128,7 @@ class kubernetes (
     $version,
     'G'
   )
+
   $_dest_dir = "${dest_dir}/kubernetes-${version}"
 
   $aia_download_url = regsubst(

--- a/puppet/modules/kubernetes/manifests/install.pp
+++ b/puppet/modules/kubernetes/manifests/install.pp
@@ -1,22 +1,45 @@
-# download and install hyperkube
-class kubernetes::install {
+# download and extract kubernets binaries
+class kubernetes::install{
   include kubernetes
 
-  $hyperkube_path = "${::kubernetes::_dest_dir}/hyperkube"
+  $archive_url = "https://dl.k8s.io/v${::kubernetes::version}/kubernetes-${::kubernetes::release_type}-${::kubernetes::os_release}-${::kubernetes::release_arch}.tar.gz"
+  $post_1_18 = versioncmp($::kubernetes::version, '1.18.0') >= 0
 
+  if $post_1_18 {
+      $checksum_type = 'sha512'
+      $checksum_url = "${archive_url}.sha512"
+  } else {
+      $checksum_type = 'sha1'
+      $checksum_url = "${archive_url}.sha1"
+  }
+  
   file { $::kubernetes::_dest_dir:
-    ensure => directory,
-    mode   => '0755',
-  }
-  -> exec {"kubernetes-${kubernetes::version}-download":
-    command => "curl -sL -o  ${hyperkube_path} ${::kubernetes::download_url}",
-    creates => $hyperkube_path,
-    path    => ['/usr/bin/', '/bin'],
-  }
-  -> file {"${::kubernetes::_dest_dir}/hyperkube":
-    ensure => file,
-    mode   => '0755',
+    ensure => 'directory',
     owner  => 'root',
     group  => 'root',
+    mode   => '0755',
+  }
+
+  archive { "${::kubernetes::_dest_dir}.tar.gz":
+    path            => "/tmp/${::kubernetes::_dest_dir}.tar.gz",
+    source          => $archive_url,
+    checksum_url    => $checksum_url,
+    checksum_type   => $checksum_type,
+    checksum_verify => true,
+    extract         => true,
+    extract_path    => $::kubernetes::_dest_dir,
+    creates         => "${::kubernetes::_dest_dir}/kubernetes",
+    cleanup         => true,
+    require         => File[$::kubernetes::_dest_dir],
+  }
+
+  $::kubernetes::binaries.each |String $binary| {
+    file { "${::kubernetes::_dest_dir}/${binary}":
+      ensure => 'present',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+      source => "${::kubernetes::_dest_dir}/kubernetes/${::kubernetes::release_type}/bin/${binary}",
+    }
   }
 }

--- a/puppet/modules/kubernetes/manifests/kubectl.pp
+++ b/puppet/modules/kubernetes/manifests/kubectl.pp
@@ -18,5 +18,7 @@ class kubernetes::kubectl(
     content => template('kubernetes/kubeconfig.erb'),
   }
 
-  kubernetes::symlink{'kubectl':}
+  if $::kubernetes::use_hyperkube {
+      kubernetes::symlink{'kubectl':}
+  }
 }

--- a/puppet/modules/kubernetes/manifests/kubelet.pp
+++ b/puppet/modules/kubernetes/manifests/kubelet.pp
@@ -319,7 +319,11 @@ class kubernetes::kubelet(
     }
   }
 
-  kubernetes::symlink{'kubelet':}
+  if $::kubernetes::use_hyperkube {
+      kubernetes::symlink{'kubelet':}
+  } else {
+      include kubernetes::install
+  }
   -> file{"${::kubernetes::systemd_dir}/${service_name}.service":
     ensure  => file,
     mode    => '0644',

--- a/puppet/modules/kubernetes/manifests/params.pp
+++ b/puppet/modules/kubernetes/manifests/params.pp
@@ -1,7 +1,9 @@
 # == Class kubernetes::params
 class kubernetes::params {
-  $version = '1.10.6'
+  $version = '1.16.15'
   $bin_dir = '/opt/bin'
+  $os_release = 'linux'
+  $release_arch = 'amd64'
   $dest_dir = '/opt'
   $config_dir = '/etc/kubernetes'
   $run_dir = '/var/run/kubernetes'

--- a/puppet/modules/kubernetes/manifests/proxy.pp
+++ b/puppet/modules/kubernetes/manifests/proxy.pp
@@ -65,7 +65,11 @@ class kubernetes::proxy(
     }
   }
 
-  kubernetes::symlink{$command_name:}
+  if $::kubernetes::use_hyperkube {
+      kubernetes::symlink{$command_name:}
+  } else {
+      include kubernetes::install
+  }
   -> file{"${::kubernetes::systemd_dir}/${service_name}.service":
     ensure  => file,
     mode    => '0644',

--- a/puppet/modules/kubernetes/manifests/scheduler.pp
+++ b/puppet/modules/kubernetes/manifests/scheduler.pp
@@ -37,7 +37,11 @@ class kubernetes::scheduler(
     $_feature_gates = $feature_gates
   }
 
-  kubernetes::symlink{$command_name:}
+  if $::kubernetes::use_hyperkube {
+      kubernetes::symlink{$command_name:}
+  } else {
+      include kubernetes::install
+  }
   -> file{$kubeconfig_path:
     ensure  => file,
     mode    => '0640',

--- a/puppet/modules/kubernetes/manifests/symlink.pp
+++ b/puppet/modules/kubernetes/manifests/symlink.pp
@@ -1,7 +1,7 @@
 # adds a symlink to hyperkube
 define kubernetes::symlink (
 ){
-  include kubernetes::install
+  include kubernetes::hyperkube_install
   File["${::kubernetes::_dest_dir}/hyperkube"]
   -> file { "${::kubernetes::_dest_dir}/${title}":
     ensure => link,

--- a/puppet/modules/kubernetes/metadata.json
+++ b/puppet/modules/kubernetes/metadata.json
@@ -15,6 +15,10 @@
       {
          "name" : "puppetlabs-concat",
          "version_requirement" : ">= 2.2.1 < 3.0.0"
+      },
+      {
+         "name" : "puppet-archive",
+         "version_requirement" : ">= 1.0.0 < 4.6.0"
       }
    ],
   "data_provider": null,


### PR DESCRIPTION
Now that hyperkube has been depricated we must download and install
individual node/server binaries as part of the puppet kubernetes module
